### PR TITLE
First, simple implementation.

### DIFF
--- a/_tabs.scss
+++ b/_tabs.scss
@@ -22,9 +22,21 @@ $tabs__variable-name: true !default;
 }
 
 
-// Tabs sub-component
+// Tab
 // ---
 
-.c-tabs__sub-component {
-    // Your component styles go here
+.c-tabs__tab {
+    &.c--is-selected {
+        color: red;
+    }
+}
+
+
+// Tabpane
+// ---
+
+.c-tabs__pane {
+    &.c--is-selected {
+        color: red;
+    }
 }

--- a/_tabs.scss
+++ b/_tabs.scss
@@ -5,6 +5,10 @@
 // ---
 
 $tabs__bg-color: #fff !default;
+$tabs__border: 1px solid $border-color !default;
+$tabs__strip-padding: 0 $unit*0.5 !default;
+$tabs__link-padding: $unit*0.5 $unit !default;
+$tabs__pane-padding: $unit*2 $unit*1.5 !default;
 
 
 // Dependencies
@@ -27,17 +31,20 @@ $tabs__bg-color: #fff !default;
     position: relative;
     display: flex;
     margin: 0;
-    padding: 0;
-    list-style: none;
-    padding: 0 $unit*0.5;
+    padding: $tabs__strip-padding;
 
-    &::after {
-        content: '';
-        position: absolute;
-        left: 0;
-        bottom: 0;
-        width: 100%;
-        border-top: 1px solid $border-color;
+    list-style: none;
+
+    @if $tabs__border == 0 && $tabs__border == none {
+    } @else {
+        &::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 0;
+            width: 100%;
+            border-top: $tabs__border;
+        }
     }
 }
 
@@ -51,25 +58,32 @@ $tabs__bg-color: #fff !default;
     flex: 1;
     width: 100%;
 
-    > a {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        min-height: $tap-size;
-        padding: $unit*0.5 $unit;
-        border: solid transparent;
-        text-decoration: none;
-    }
-
     &.c--is-selected {
         z-index: 10;
-
-        > a {
-            background: $tabs__bg-color;
-            border-color: $border-color;
-            border-width: 1px 1px 0 1px;
-        }
     }
+}
+
+
+// Links
+// ---
+
+.c-tabs__link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: $tap-size;
+    padding: $tabs__link-padding;
+
+    background: $tabs__bg-color;
+    border: solid transparent;
+
+    @if $tabs__border == 0 && $tabs__border == none {
+    } @else {
+        border-color: $border-color;
+        border-width: 1px 1px 0 1px;
+    }
+
+    text-decoration: none;
 }
 
 
@@ -79,7 +93,7 @@ $tabs__bg-color: #fff !default;
 .c-tabs__pane {
     display: none;
     background: $tabs__bg-color;
-    padding: $unit*2 $unit*1.5;
+    padding: $tabs__pane-padding;
 
     &.c--is-selected {
         display: block;

--- a/_tabs.scss
+++ b/_tabs.scss
@@ -58,7 +58,6 @@ $tabs__bg-color: #fff !default;
         min-height: $tap-size;
         padding: $unit*0.5 $unit;
         border: solid transparent;
-        outline: none;
         text-decoration: none;
     }
 

--- a/_tabs.scss
+++ b/_tabs.scss
@@ -17,11 +17,7 @@ $tabs__bg-color: #fff !default;
 // Tabs root
 // ---
 
-.c-tabs {
-    display: block;
-    margin: 0;
-    padding: 0;
-}
+.c-tabs {}
 
 
 // Tab strip
@@ -68,12 +64,12 @@ $tabs__bg-color: #fff !default;
 
     &.c--is-selected {
         z-index: 10;
-    }
 
-    &.c--is-selected > a {
-        background: $tabs__bg-color;
-        border-color: $border-color;
-        border-width: 1px 1px 0 1px;
+        > a {
+            background: $tabs__bg-color;
+            border-color: $border-color;
+            border-width: 1px 1px 0 1px;
+        }
     }
 }
 

--- a/_tabs.scss
+++ b/_tabs.scss
@@ -4,7 +4,7 @@
 // Configurable Variables
 // ---
 
-$tabs__variable-name: true !default;
+$tabs__bg-color: #fff !default;
 
 
 // Dependencies
@@ -18,7 +18,31 @@ $tabs__variable-name: true !default;
 // ---
 
 .c-tabs {
-    // Your component styles go here
+    display: block;
+    margin: 0;
+    padding: 0;
+}
+
+
+// Tab strip
+// ---
+
+.c-tabs__strip {
+    position: relative;
+    display: flex;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    padding: 0 $unit*0.5;
+
+    &::after {
+        content: '';
+        position: absolute;
+        left: 0;
+        bottom: 0;
+        width: 100%;
+        border-top: 1px solid $border-color;
+    }
 }
 
 
@@ -26,8 +50,30 @@ $tabs__variable-name: true !default;
 // ---
 
 .c-tabs__tab {
+    position: relative;
+    display: block;
+    flex: 1;
+    width: 100%;
+
+    > a {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: $tap-size;
+        padding: $unit*0.5 $unit;
+        border: solid transparent;
+        outline: none;
+        text-decoration: none;
+    }
+
     &.c--is-selected {
-        color: red;
+        z-index: 10;
+    }
+
+    &.c--is-selected > a {
+        background: $tabs__bg-color;
+        border-color: $border-color;
+        border-width: 1px 1px 0 1px;
     }
 }
 
@@ -36,7 +82,11 @@ $tabs__variable-name: true !default;
 // ---
 
 .c-tabs__pane {
+    display: none;
+    background: $tabs__bg-color;
+    padding: $unit*2 $unit*1.5;
+
     &.c--is-selected {
-        color: red;
+        display: block;
     }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "url": "http://github.com/mobify/stencil-tabs.git"
   },
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "jquery": "^2.1.4"
+  },
   "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-autoprefixer": "2.0.0",

--- a/tabs-ui.js
+++ b/tabs-ui.js
@@ -37,11 +37,14 @@ define(['$'], function($) {
         this.$tabs.each(function(i, tab) {
             var tabId = 'stencil-tab-' + self.instanceId + '.' + i;
             var paneId = 'stencil-tabpane-' + self.instanceId + '.' + i;
+            var $tab = $(tab);
+            var $tabAnchor = $(tab).find('a');
 
-            $(tab).attr({
+            $tabAnchor.attr({
                 'id': tabId,
+                'href': '#' + paneId,
                 'aria-controls': paneId,
-                'tabindex': '0',
+                'tabindex': '-1',
                 'aria-selected': 'false',
             });
 
@@ -64,19 +67,25 @@ define(['$'], function($) {
             return;
         }
 
-        this.$tabs.eq(this.selectedIndex).attr({
-            'tabindex': '-1',
-            'aria-selected': 'false',
-        }).removeClass('c--is-selected');
+        this.$tabs.eq(this.selectedIndex)
+            .removeClass('c--is-selected')
+            .find('a')
+            .attr({
+                'tabindex': '-1',
+                'aria-selected': 'false',
+            });
 
         this.$panes.eq(this.selectedIndex).attr({
             'aria-hidden': 'true',
         }).removeClass('c--is-selected');
 
-        this.$tabs.eq(index).attr({
-            'tabindex': '0',
-            'aria-selected': 'true',
-        }).addClass('c--is-selected');
+        this.$tabs.eq(index)
+            .addClass('c--is-selected')
+            .find('a')
+            .attr({
+                'tabindex': '0',
+                'aria-selected': 'true',
+            });
 
         this.$panes.eq(index)
             .removeAttr('aria-hidden')

--- a/tabs-ui.js
+++ b/tabs-ui.js
@@ -56,7 +56,7 @@ define(['$'], function($) {
         });
 
         this.$el.on('click', '.c-tabs__tab', function(event) {
-            event.preventDefault;
+            event.preventDefault();
 
             self.select(self.$tabs.index(this));
         });

--- a/tabs-ui.js
+++ b/tabs-ui.js
@@ -1,11 +1,95 @@
-define([
-    '$'
-], function($) {
+define(['$'], function($) {
+    /**
+     * Coordinator singleton
+     *
+     * Manages setting unique ids for tabs/tabpanes.
+     */
+    var TabsCoordinator = function() {
+        if (TabsCoordinator.prototype._singletonInstance) {
+            return TabsCoordinator.prototype._singletonInstance;
+        }
 
-    var init = function() {
+        this.counter = 0;
+
+        TabsCoordinator.prototype._singletonInstance = this;
+    }
+
+    /**
+     * Get the next available id
+     */
+    TabsCoordinator.prototype.nextIndex = function() {
+        return this.counter++;
+    };
+
+    /**
+     * Tabs constructor
+     */
+    var Tabs = function($el, options) {
+        var self = this;
+        var coordinator = new TabsCoordinator();
+
+        this.instanceId = coordinator.nextIndex();
+        this.$el = $el;
+        this.$tabs = $el.find('.c-tabs__tab');
+        this.$panes = $el.find('.c-tabs__pane');
+        this.selectedIndex = parseInt(this.$el.attr('data-selected-index'), 10) || 0;
+
+        this.$tabs.each(function(i, tab) {
+            var tabId = 'stencil-tab-' + self.instanceId + '.' + i;
+            var paneId = 'stencil-tabpane-' + self.instanceId + '.' + i;
+
+            $(tab).attr({
+                'id': tabId,
+                'aria-controls': paneId,
+                'tabindex': '0',
+                'aria-selected': 'false',
+            });
+
+            self.$panes.eq(i).attr({
+                'id': paneId,
+                'aria-labelledby': tabId,
+                'aria-hidden': 'true',
+            });
+        });
+
+        this.$el.on('click', '.c-tabs__tab', function(event) {
+            self.select(self.$tabs.index(this));
+        });
+
+        this.select(this.selectedIndex);
+    }
+
+    Tabs.prototype.select = function(index) {
+        if (this.selectedIndex === index && this.$tabs.find('.c--is-selected').length) {
+            return;
+        }
+
+        this.$tabs.eq(this.selectedIndex).attr({
+            'tabindex': '-1',
+            'aria-selected': 'false',
+        }).removeClass('c--is-selected');
+
+        this.$panes.eq(this.selectedIndex).attr({
+            'aria-hidden': 'true',
+        }).removeClass('c--is-selected');
+
+        this.$tabs.eq(index).attr({
+            'tabindex': '0',
+            'aria-selected': 'true',
+        }).addClass('c--is-selected');
+
+        this.$panes.eq(index)
+            .removeAttr('aria-hidden')
+            .addClass('c--is-selected');
+
+        this.selectedIndex = index;
     };
 
     return {
-        init: init
+        init: function($el, options) {
+            // If already initialized, return the instance; otherwise, create it
+            // and expose it through `$('.c-tabs').data('component')`.
+            return $el.data('component') || $el.data('component', new Tabs($el, options));
+        }
     };
 });

--- a/tabs-ui.js
+++ b/tabs-ui.js
@@ -56,6 +56,8 @@ define(['$'], function($) {
         });
 
         this.$el.on('click', '.c-tabs__tab', function(event) {
+            event.preventDefault;
+
             self.select(self.$tabs.index(this));
         });
 

--- a/tabs.dust
+++ b/tabs.dust
@@ -1,3 +1,23 @@
-<div {?id}id="{.}"{/id} class="c-tabs {class}" {?role}role="{.}"{/role} data-adaptivejs-component="stencil-tabs">
-    Component stuff goes here!
+<div class="c-tabs {class}"
+    {?id}id="{id}"{/id}
+    {?selectedIndex}data-selected-index="{selectedIndex}"{/selectedIndex}
+    data-adaptivejs-component="stencil-tabs"
+>
+    <ol class="c-tabs__strip">
+        {?tabStrip}
+            {tabStrip}
+        {:else}
+            {#tabs}
+                {@c-tabs__tab}{label}{/c-tabs__tab}
+            {/tabs}
+        {/tabStrip}
+    </ol>
+
+    {?body}
+        {body}
+    {:else}
+        {#panes}
+            {@c-tabs__pane}{contents}{/c-tabs__pane}
+        {/panes}
+    {/body}
 </div>

--- a/tabs__pane.dust
+++ b/tabs__pane.dust
@@ -1,0 +1,3 @@
+<div class="c-tabs__pane">
+    {body}
+</div>

--- a/tabs__pane.dust
+++ b/tabs__pane.dust
@@ -1,3 +1,3 @@
-<div class="c-tabs__pane">
+<div class="c-tabs__pane {class}">
     {body}
 </div>

--- a/tabs__tab.dust
+++ b/tabs__tab.dust
@@ -1,4 +1,4 @@
-<li class="c-tabs__tab {class}" role="presentation">
+<li class="c-tabs__tab {class}" {?id}id="{id}"{/id} role="presentation">
     <a class="c-tabs__link {linkClass}" role="tab">
         {body}
     </a>

--- a/tabs__tab.dust
+++ b/tabs__tab.dust
@@ -1,5 +1,5 @@
 <li class="c-tabs__tab {class}" role="presentation">
-    <a role="tab">
+    <a class="c-tabs__link {linkClass}" role="tab">
         {body}
     </a>
 </li>

--- a/tabs__tab.dust
+++ b/tabs__tab.dust
@@ -1,0 +1,5 @@
+<li role="presentation">
+    <a class="c-tabs__tab {class}" role="tab">
+        {body}
+    </a>
+</li>

--- a/tabs__tab.dust
+++ b/tabs__tab.dust
@@ -1,5 +1,5 @@
-<li role="presentation">
-    <a class="c-tabs__tab {class}" role="tab">
+<li class="c-tabs__tab {class}" role="presentation">
+    <a role="tab">
         {body}
     </a>
 </li>

--- a/tests/visual/runner.js
+++ b/tests/visual/runner.js
@@ -2,25 +2,24 @@ require.config({
     paths: {
         'dust-full': '../../node_modules/dustjs-linkedin/dist/dust-full',
         'adaptivejs': '../../node_modules/adaptivejs',
+        '$': '../../node_modules/jquery/dist/jquery',
     },
     shim: {
         'dust-full': {
             'exports': 'dust'
+        },
+        '$': {
+            'exports': 'jQuery'
         }
     },
 });
 
-require([
-    'dust-full',
-    'adaptivejs/lib/dust-component-helper',
-    'adaptivejs/lib/dust-component-sugar',
-    '../../tmp/templates'
-], function(
-    dust,
-    componentHelper,
-    componentSugar,
-    templates
-) {
+define(function(require) {
+    var dust = require('dust-full');
+    var componentHelper = require('adaptivejs/lib/dust-component-helper');
+    var componentSugar = require('adaptivejs/lib/dust-component-sugar');
+    var templates = require('../../tmp/templates');
+    var ui = require('../../tabs-ui');
     var context;
 
     // Register helpers for precompiled component templates.
@@ -32,13 +31,25 @@ require([
     // Define any context required for the tests:
     var context = {
         repo: 'https://github.com/mobify/stencil-tabs',
-        selectMarkup: 'Insert example markup here',
+        tabs: [
+            {label: 'Tab One'}, {label: 'Tab Two'}, {label: 'Tab Three'},
+        ],
+        sections: [
+            {contents: 'Pane One'}, {contents: 'Pane Two'}, {contents: 'Pane Three'},
+        ],
     };
 
     // Render
     dust.render('tests', context, function(err, out) {
         if (!err) {
             document.querySelector('body').innerHTML = out;
+
+            $('[data-adaptivejs-component="stencil-tabs"]').each(function(i, el) {
+                var $component = $(el);
+
+                ui.init($component);
+                $component.attr('data-adaptivejs-component-processed', '');
+            });
         } else {
             console.log(err);
         }

--- a/tests/visual/tests.dust
+++ b/tests/visual/tests.dust
@@ -4,8 +4,41 @@
 
 {@c-spec for="Tabs Component" repository=repo}
     {@c-spec__test describe=".c-tabs"}
-        {@c-spec__case expect="Should have feature A"}
-            {@c-tabs /}
+        {@c-spec__case expect="Should render tabs using the shorthand helper"}
+
+            {@c-tabs tabs=tabs panes=sections /}
+
+        {/c-spec__case}
+
+        {@c-spec__case expect="Should render tabs using the fully expanded helper"}
+
+            {@c-tabs}
+            {:tabStrip}
+                {#tabs}
+                    {@c-tabs__tab}{label}{/c-tabs__tab}
+                {/tabs}
+            {:body}
+                {#sections}
+                    {@c-tabs__pane}{contents}{/c-tabs__pane}
+                {/sections}
+            {/c-tabs}
+
+        {/c-spec__case}
+
+        {@c-spec__case expect="Should render tabs using mixed helper"}
+
+            {@c-tabs tabs=tabs}
+                {#sections}
+                    {@c-tabs__pane}{contents}{/c-tabs__pane}
+                {/sections}
+            {/c-tabs}
+
+        {/c-spec__case}
+
+        {@c-spec__case expect="Should default to the second tab selected"}
+
+            {@c-tabs tabs=tabs panes=sections selectedIndex="1" /}
+
         {/c-spec__case}
     {/c-spec__test}
 {/c-spec}


### PR DESCRIPTION
This is a simple implementation of Tabs with ARIA support. There’s not stylesheet yet. Also, contra what I originally wanted, this doesn’t split the panes into its own component. I would still like to do that, but there’s not time at the moment to figure out the engineering for that.

Status: **WIP**
Owner: @ry5n
Reviewers: @jeffkamo 
## Changes
- Adds initial templates (tabs container, single tab, single pane)
- Adds UI script
- Adds placeholder styles for debugging only
## Jira Tickets:
- [STEN-20](https://mobify.atlassian.net/browse/STEN-20) 
## Todos:
- [ ] Engineer +1
- [ ] Designer +1
## How to Test
- clone this repo
- `cd stencil-select`
- `npm install && bower install && bundle install`
- run `grunt serve`
- Check the command line output to determine which port the server started at (defaults to 3000)
- Navigate to `localhost:{port}/tests/visual/`
